### PR TITLE
Improve OR-Tools build script robustness and portability

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,24 +1,54 @@
 extern crate prost_build;
 
+use std::path::PathBuf;
+
 fn main() {
+    println!("cargo:rerun-if-env-changed=ORTOOLS_PREFIX");
+    println!("cargo:rerun-if-changed=src/cp_sat_wrapper.cpp");
+    println!("cargo:rerun-if-changed=src/cp_model.proto");
+    println!("cargo:rerun-if-changed=src/sat_parameters.proto");
+
+    if std::env::var("DOCS_RS").is_ok() {
+        return;
+    }
+
     prost_build::compile_protos(
         &["src/cp_model.proto", "src/sat_parameters.proto"],
         &["src/"],
     )
     .unwrap();
 
-    if std::env::var("DOCS_RS").is_err() {
-        let ortools_prefix = std::env::var("ORTOOLS_PREFIX")
-            .ok()
-            .unwrap_or_else(|| "/opt/ortools".into());
-        cc::Build::new()
-            .cpp(true)
-            .flags(["-std=c++17", "-DOR_PROTO_DLL="])
-            .file("src/cp_sat_wrapper.cpp")
-            .include([&ortools_prefix, "/include"].concat())
-            .compile("cp_sat_wrapper.a");
+    let ortools_prefix = std::env::var("ORTOOLS_PREFIX")
+        .ok()
+        .unwrap_or_else(|| "/opt/ortools".into());
 
-        println!("cargo:rustc-link-lib=dylib=ortools");
-        println!("cargo:rustc-link-search=native={}/lib", ortools_prefix);
+    let prefix = PathBuf::from(&ortools_prefix);
+
+    cc::Build::new()
+        .cpp(true)
+        .flags(["-std=c++17", "-DOR_PROTO_DLL="])
+        .file("src/cp_sat_wrapper.cpp")
+        .include(prefix.join("include"))
+        .compile("cp_sat_wrapper.a");
+
+    println!("cargo:rustc-link-lib=ortools");
+    println!("cargo:rustc-link-lib=protobuf");
+
+    let lib = prefix.join("lib");
+    let lib64 = prefix.join("lib64");
+
+    for dir in [&lib, &lib64] {
+        if dir.exists() {
+            println!("cargo:rustc-link-search=native={}", dir.display());
+        }
+    }
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if target_os == "linux" {
+        for dir in [&lib, &lib64] {
+            if dir.exists() {
+                println!("cargo:rustc-link-arg=-Wl,-rpath,{}", dir.display());
+            }
+        }
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,59 @@ extern crate prost_build;
 
 use std::path::PathBuf;
 
+const ORTOOLS_PREFIX_CANDIDATES: &[&str] = &[
+    "/usr/local",
+    "/usr",
+    "/opt/homebrew",
+    "/home/linuxbrew/.linuxbrew",
+    "/opt/ortools",
+];
+
+// Find the OR-Tools installation prefix.
+//
+// Discovery order:
+//   First: `$ORTOOLS_PREFIX` environment variable (prioritized override)
+//   After:  sequentially checks candidates in `ORTOOLS_PREFIX_CANDIDATES` (see above)
+//
+// Returns `None` when no installation can be found.
+fn find_ortools_prefix() -> Option<PathBuf> {
+    if let Ok(prefix) = std::env::var("ORTOOLS_PREFIX") {
+        let p = PathBuf::from(&prefix);
+        // Honour the user's choice even if the header is missing
+        return Some(p);
+    }
+
+    for candidate in ORTOOLS_PREFIX_CANDIDATES {
+        let p = PathBuf::from(candidate);
+        if p.join("include/ortools/sat/cp_model.h").exists() {
+            return Some(p);
+        }
+    }
+
+    None
+}
+
+// Error message listing every location that was probed.
+fn build_error_message() -> String {
+    let mut msg = String::from(
+        "error: OR-Tools installation not found.\n\
+         Tried the following locations:\n\n",
+    );
+
+    msg.push_str(" 1. $ORTOOLS_PREFIX (not set)\n");
+    for (i, candidate) in ORTOOLS_PREFIX_CANDIDATES.iter().enumerate() {
+        msg.push_str(&format!(" {}. {}\n", i + 2, candidate));
+    }
+
+    msg.push_str(
+        "\nInstall OR-Tools (https://developers.google.com/optimization/install)\n\
+         and either set ORTOOLS_PREFIX to the installation prefix or install\n\
+         to one of the standard locations listed above.",
+    );
+
+    msg
+}
+
 fn main() {
     println!("cargo:rerun-if-env-changed=ORTOOLS_PREFIX");
     println!("cargo:rerun-if-changed=src/cp_sat_wrapper.cpp");
@@ -18,12 +71,16 @@ fn main() {
     )
     .unwrap();
 
-    let ortools_prefix = std::env::var("ORTOOLS_PREFIX")
-        .ok()
-        .unwrap_or_else(|| "/opt/ortools".into());
+    // OR-Tools prefix discovery
+    let prefix = match find_ortools_prefix() {
+        Some(p) => p,
+        None => {
+            eprintln!("{}", build_error_message());
+            std::process::exit(1);
+        }
+    };
 
-    let prefix = PathBuf::from(&ortools_prefix);
-
+    // C++ wrapper compilation
     cc::Build::new()
         .cpp(true)
         .flags(["-std=c++17", "-DOR_PROTO_DLL="])
@@ -31,6 +88,7 @@ fn main() {
         .include(prefix.join("include"))
         .compile("cp_sat_wrapper.a");
 
+    // Linker configuration
     println!("cargo:rustc-link-lib=ortools");
     println!("cargo:rustc-link-lib=protobuf");
 
@@ -43,6 +101,7 @@ fn main() {
         }
     }
 
+    // Linux RPATH injection
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     if target_os == "linux" {
         for dir in [&lib, &lib64] {


### PR DESCRIPTION
I improved the OR-Tools build integration to make it more portable and easier to use without manual linker configuration. Tested with CMake-built OR-Tools v9.15.

- I added support for multiple OR-Tools installation layouts by searching both `{prefix}/lib` and `{prefix}/lib64` instead of only `{prefix}/lib`, improving compatibility with different Linux distributions.
- I improved the include path construction with PathBuf::join, making include path handling safer and fully cross-platform.
- I added automatic linking of libprotobuf, removing the need for users to manually pass RUSTFLAGS="-lprotobuf" when using newer OR-Tools versions. This _should_ be compatible with older versions (linker usually ignores duplicates safely)
- I removed `dylib=ortools` in favor of a generic `ortools` link instruction, making linkage more flexible for static or mixed builds.
- I added Linux-specific RPATH injection so that runtime library resolution works without requiring LD_LIBRARY_PATH.
- I scoped RPATH handling to binaries and tests using cargo:rustc-link-arg (instead of relying on external environment configuration).
- I added rebuild triggers for ORTOOLS_PREFIX, C++ sources, and protobuf definitions to ensure correct incremental rebuild behavior.

## Further Steps

I would like to take this one step further and make OR-Tools discovery automatic. One idea is to introduce the cmake crate and attempt to locate an installed OR-Tools package via its CMake configuration when ORTOOLS_PREFIX is not set.

What are your thoughts on using CMake-based discovery as the primary lookup mechanism, with ORTOOLS_PREFIX retained as an override?