### PR TITLE
Add solve_with_callback for streaming solutions and early interruption

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,9 +13,18 @@ fn main() {
             .unwrap_or_else(|| "/opt/ortools".into());
         cc::Build::new()
             .cpp(true)
-            .flags(["-std=c++17", "-DOR_PROTO_DLL="])
+            // OR-Tools' published binaries are built with NDEBUG. Compiling the
+            // wrapper against its headers without NDEBUG instantiates the
+            // debug variant of Abseil's containers (e.g. the absl::flat_hash_map
+            // behind sat::Model::GetOrCreate), which references debug-only Abseil
+            // symbols absent from the release libs and is an ODR violation. Match
+            // the library's configuration.
+            .flags(["-std=c++17", "-DOR_PROTO_DLL=", "-DNDEBUG"])
+            // Pull the OR-Tools headers in as system headers so their own
+            // diagnostics (unused params, sign comparisons, ...) stay out of the
+            // build log; warnings in our own wrapper still surface normally.
+            .flag(&format!("-isystem{}/include", ortools_prefix))
             .file("src/cp_sat_wrapper.cpp")
-            .include([&ortools_prefix, "/include"].concat())
             .compile("cp_sat_wrapper.a");
 
         println!("cargo:rustc-link-lib=dylib=ortools");

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -850,6 +850,41 @@ impl CpModelBuilder {
     pub fn solve_with_parameters(&self, params: &proto::SatParameters) -> proto::CpSolverResponse {
         ffi::solve_with_parameters(self.proto(), params)
     }
+
+    /// Solves the model with the given
+    /// [parameters][proto::SatParameters], reporting every improving
+    /// solution to `on_solution` and allowing the search to be stopped
+    /// early through `stop`.
+    ///
+    /// See [ffi::solve_with_callback] for the threading and interruption
+    /// semantics: `on_solution` is called from a solver-owned thread (calls
+    /// are serialised, never concurrent), and setting `stop` to `true` from
+    /// any thread requests an early stop returning the best solution so far.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use cp_sat::builder::CpModelBuilder;
+    /// # use cp_sat::proto::{CpSolverStatus, SatParameters};
+    /// let mut model = CpModelBuilder::default();
+    /// let x = model.new_int_var([(0, 10)]);
+    /// model.maximize(x);
+    /// let mut seen = 0;
+    /// let response = model.solve_with_callback(&SatParameters::default(), None, |_| seen += 1);
+    /// assert_eq!(response.status(), CpSolverStatus::Optimal);
+    /// assert!(seen >= 1);
+    /// ```
+    pub fn solve_with_callback<F>(
+        &self,
+        params: &proto::SatParameters,
+        stop: Option<&std::sync::atomic::AtomicBool>,
+        on_solution: F,
+    ) -> proto::CpSolverResponse
+    where
+        F: FnMut(&proto::CpSolverResponse) + Send,
+    {
+        ffi::solve_with_callback(self.proto(), params, stop, on_solution)
+    }
 }
 
 /// Boolean variable identifier.

--- a/src/cp_sat_wrapper.cpp
+++ b/src/cp_sat_wrapper.cpp
@@ -1,7 +1,12 @@
+#include <atomic>
 #include <iostream>
+#include <string>
 
 #include <ortools/sat/cp_model.h>
 #include <ortools/sat/cp_model_checker.h>
+#include <ortools/sat/cp_model_solver.h>
+#include <ortools/sat/model.h>
+#include <ortools/util/time_limit.h>
 
 namespace sat = operations_research::sat;
 
@@ -12,7 +17,7 @@ cp_sat_wrapper_solve(
     size_t* out_size)
 {
     sat::CpModelProto model;
-    bool res = model.ParseFromArray(model_buf, model_size);
+    [[maybe_unused]] bool res = model.ParseFromArray(model_buf, model_size);
     assert(res);
 
     sat::CpSolverResponse response = sat::Solve(model);
@@ -34,7 +39,7 @@ cp_sat_wrapper_solve(
      size_t* out_size)
  {
     sat::CpModelProto model;
-    bool res = model.ParseFromArray(model_buf, model_size);
+    [[maybe_unused]] bool res = model.ParseFromArray(model_buf, model_size);
     assert(res);
 
     sat::SatParameters params;
@@ -54,7 +59,7 @@ cp_sat_wrapper_solve(
 extern "C" char*
 cp_sat_wrapper_cp_model_stats(unsigned char* model_buf, size_t model_size) {
     sat::CpModelProto model;
-    const bool res = model.ParseFromArray(model_buf, model_size);
+    [[maybe_unused]] const bool res = model.ParseFromArray(model_buf, model_size);
     assert(res);
 
     const std::string stats = sat::CpModelStats(model);
@@ -68,7 +73,7 @@ cp_sat_wrapper_cp_solver_response_stats(
     bool has_objective)
 {
     sat::CpSolverResponse response;
-    const bool res = response.ParseFromArray(response_buf, response_size);
+    [[maybe_unused]] const bool res = response.ParseFromArray(response_buf, response_size);
     assert(res);
 
     const std::string stats = sat::CpSolverResponseStats(response, has_objective);
@@ -78,7 +83,7 @@ cp_sat_wrapper_cp_solver_response_stats(
 extern "C" char*
 cp_sat_wrapper_validate_cp_model(unsigned char* model_buf, size_t model_size) {
     sat::CpModelProto model;
-    const bool res = model.ParseFromArray(model_buf, model_size);
+    [[maybe_unused]] const bool res = model.ParseFromArray(model_buf, model_size);
     assert(res);
 
     const std::string stats = sat::ValidateCpModel(model);
@@ -93,7 +98,7 @@ cp_sat_wrapper_solution_is_feasible(
     size_t solution_size)
 {
     sat::CpModelProto model;
-    const bool res = model.ParseFromArray(model_buf, model_size);
+    [[maybe_unused]] const bool res = model.ParseFromArray(model_buf, model_size);
     assert(res);
 
     std::vector<int64_t> variable_values;
@@ -103,4 +108,62 @@ cp_sat_wrapper_solution_is_feasible(
     }
 
     return sat::SolutionIsFeasible(model, variable_values);
+}
+
+extern "C" unsigned char*
+cp_sat_wrapper_solve_with_callback(
+    const unsigned char* model_buf,
+    size_t model_size,
+    const unsigned char* params_buf,
+    size_t params_size,
+    const unsigned char* stop_flag,
+    void* user_data,
+    void (*solution_cb)(void* user_data, const unsigned char* resp_buf, size_t resp_size),
+    size_t* out_size)
+{
+    static_assert(sizeof(std::atomic<bool>) == 1,
+                  "std::atomic<bool> must be one byte to alias a Rust AtomicBool");
+    static_assert(std::atomic<bool>::is_always_lock_free,
+                  "std::atomic<bool> must be lock-free to alias a Rust AtomicBool");
+
+    sat::CpModelProto model_proto;
+    [[maybe_unused]] bool res = model_proto.ParseFromArray(model_buf, model_size);
+    assert(res);
+
+    sat::SatParameters params;
+    res = params.ParseFromArray(params_buf, params_size);
+    assert(res);
+
+    sat::Model model;
+    model.Add(sat::NewSatParameters(params));
+
+    // Registering our boolean before any solver-internal ModelSharedTimeLimit is
+    // built makes the solver adopt it as the shared stop signal for every worker
+    // (see SharedTimeLimit's constructor in util/time_limit.h).
+    if (stop_flag != nullptr) {
+        std::atomic<bool>* flag =
+            reinterpret_cast<std::atomic<bool>*>(const_cast<unsigned char*>(stop_flag));
+        model.GetOrCreate<operations_research::TimeLimit>()
+            ->RegisterExternalBooleanAsLimit(flag);
+    }
+
+    if (solution_cb != nullptr) {
+        model.Add(sat::NewFeasibleSolutionObserver(
+            [user_data, solution_cb](const sat::CpSolverResponse& response) {
+                std::string buf;
+                response.SerializeToString(&buf);
+                solution_cb(user_data,
+                            reinterpret_cast<const unsigned char*>(buf.data()),
+                            buf.size());
+            }));
+    }
+
+    sat::CpSolverResponse response = sat::SolveCpModel(model_proto, &model);
+
+    *out_size = response.ByteSizeLong();
+    unsigned char* out_buf = (unsigned char*) malloc(*out_size);
+    res = response.SerializeToArray(out_buf, *out_size);
+    assert(res);
+
+    return out_buf;
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,7 +1,9 @@
 use crate::proto;
 use libc::c_char;
 use prost::Message;
-use std::ffi::CStr;
+use std::ffi::{c_void, CStr};
+use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 extern "C" {
     fn cp_sat_wrapper_solve(
@@ -29,6 +31,16 @@ extern "C" {
         solution_buf: *const i64,
         solution_size: usize,
     ) -> bool;
+    fn cp_sat_wrapper_solve_with_callback(
+        model_buf: *const u8,
+        model_size: usize,
+        params_buf: *const u8,
+        params_size: usize,
+        stop_flag: *const u8,
+        user_data: *mut c_void,
+        solution_cb: Option<extern "C" fn(*mut c_void, *const u8, usize)>,
+        out_size: &mut usize,
+    ) -> *mut u8;
 }
 
 /// Solves the given [CpModelProto][crate::proto::CpModelProto] and
@@ -69,6 +81,119 @@ pub fn solve_with_parameters(
     let out_slice = unsafe { std::slice::from_raw_parts(res, out_size) };
     let response = proto::CpSolverResponse::decode(out_slice).unwrap();
     unsafe { libc::free(res as _) };
+    response
+}
+
+/// Solves the given [CpModelProto][crate::proto::CpModelProto] with the given
+/// parameters, streaming improving solutions to `on_solution` and allowing the
+/// search to be interrupted.
+///
+/// `on_solution` is invoked with each improving feasible
+/// [CpSolverResponse][crate::proto::CpSolverResponse] the solver finds (for a
+/// satisfaction problem solved with `enumerate_all_solutions`, it is invoked for
+/// every solution instead). The closure runs on a solver-owned thread, but
+/// OR-Tools serialises these calls so they never overlap — hence `FnMut`
+/// (exclusive access) is sufficient and `Sync` is not required.
+///
+/// If `stop` is `Some`, storing `true` into it from any thread asks the solver
+/// to stop as soon as possible and return the best solution found so far. The
+/// borrow guarantees the flag outlives the solve.
+///
+/// # Panics
+///
+/// If `on_solution` panics, the panic is caught before it can unwind through the
+/// C++ frames (which would be undefined behaviour); the search is then asked to
+/// stop and the panic is re-raised on this thread once the solver returns. Any
+/// solutions reported after the first panic are ignored.
+pub fn solve_with_callback<F>(
+    model: &proto::CpModelProto,
+    params: &proto::SatParameters,
+    stop: Option<&AtomicBool>,
+    on_solution: F,
+) -> proto::CpSolverResponse
+where
+    F: FnMut(&proto::CpSolverResponse) + Send,
+{
+    struct Context<F> {
+        on_solution: F,
+        stop: *const AtomicBool,
+        panic: Option<Box<dyn std::any::Any + Send + 'static>>,
+    }
+
+    extern "C" fn trampoline<F: FnMut(&proto::CpSolverResponse)>(
+        user_data: *mut c_void,
+        resp_buf: *const u8,
+        resp_size: usize,
+    ) {
+        // SAFETY: `user_data` points at the `Context` owned by the enclosing
+        // `solve_with_callback` call, which blocks until the solver returns and
+        // therefore outlives every callback. OR-Tools serialises observer calls,
+        // so no two `&mut Context` references are ever live at the same time.
+        let context = unsafe { &mut *(user_data as *mut Context<F>) };
+        if context.panic.is_some() {
+            return;
+        }
+        let slice = unsafe { std::slice::from_raw_parts(resp_buf, resp_size) };
+        let response = match proto::CpSolverResponse::decode(slice) {
+            Ok(response) => response,
+            Err(_) => return,
+        };
+        let outcome = {
+            let on_solution = &mut context.on_solution;
+            catch_unwind(AssertUnwindSafe(|| on_solution(&response)))
+        };
+        if let Err(payload) = outcome {
+            // A panic must never unwind across the C++ frames. Capture it, ask
+            // the solver to stop, and re-raise it once `Solve` has returned.
+            context.panic = Some(payload);
+            if !context.stop.is_null() {
+                unsafe { (*context.stop).store(true, Ordering::SeqCst) };
+            }
+        }
+    }
+
+    let mut model_buf = Vec::default();
+    model.encode(&mut model_buf).unwrap();
+    let mut params_buf = Vec::default();
+    params.encode(&mut params_buf).unwrap();
+
+    let stop_ptr = stop.map_or(std::ptr::null(), |flag| flag as *const AtomicBool);
+    let mut context = Context {
+        on_solution,
+        stop: stop_ptr,
+        panic: None,
+    };
+    let user_data = &mut context as *mut Context<F> as *mut c_void;
+
+    let mut out_size = 0;
+    let res = unsafe {
+        cp_sat_wrapper_solve_with_callback(
+            model_buf.as_ptr(),
+            model_buf.len(),
+            params_buf.as_ptr(),
+            params_buf.len(),
+            stop_ptr as *const u8,
+            user_data,
+            Some(trampoline::<F>),
+            &mut out_size,
+        )
+    };
+
+    // `out_size == 0` makes a conforming `malloc` free to return null, so guard
+    // it rather than building a slice from a null pointer.
+    let response = if res.is_null() {
+        proto::CpSolverResponse::default()
+    } else {
+        let out_slice = unsafe { std::slice::from_raw_parts(res, out_size) };
+        let decoded = proto::CpSolverResponse::decode(out_slice).unwrap();
+        unsafe { libc::free(res as _) };
+        decoded
+    };
+
+    if let Some(payload) = context.panic.take() {
+        resume_unwind(payload);
+    }
+
     response
 }
 

--- a/tests/callback.rs
+++ b/tests/callback.rs
@@ -1,0 +1,51 @@
+use std::sync::atomic::AtomicBool;
+
+use cp_sat::builder::{CpModelBuilder, LinearExpr};
+use cp_sat::proto::{CpSolverStatus, SatParameters};
+
+#[test]
+fn reports_solutions_and_returns_optimal() {
+    let mut model = CpModelBuilder::default();
+    let xs: Vec<_> = (0..20).map(|_| model.new_bool_var()).collect();
+    model.maximize(xs.iter().copied().collect::<LinearExpr>());
+
+    let mut count = 0;
+    let response = model.solve_with_callback(&SatParameters::default(), None, |_| count += 1);
+
+    assert_eq!(response.status(), CpSolverStatus::Optimal);
+    assert!(count >= 1, "expected at least one improving solution");
+}
+
+#[test]
+fn preset_stop_flag_does_not_hang() {
+    let mut model = CpModelBuilder::default();
+    let xs: Vec<_> = (0..40).map(|_| model.new_bool_var()).collect();
+    model.maximize(xs.iter().copied().collect::<LinearExpr>());
+
+    let stop = AtomicBool::new(true);
+    let mut params = SatParameters::default();
+    params.max_time_in_seconds = Some(60.0);
+
+    let response = model.solve_with_callback(&params, Some(&stop), |_| {});
+
+    assert!(
+        response.wall_time < 10.0,
+        "a pre-set stop flag should make the solver return promptly, not run to the cap"
+    );
+}
+
+#[test]
+fn callback_panic_propagates_to_caller() {
+    let mut model = CpModelBuilder::default();
+    let x = model.new_bool_var();
+    model.maximize(x);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        model.solve_with_callback(&SatParameters::default(), None, |_| panic!("boom"));
+    }));
+
+    assert!(
+        result.is_err(),
+        "a panic inside the callback must be re-raised on the calling thread"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `CpModelBuilder::solve_with_callback` (and the underlying `ffi::solve_with_callback`), which solves a model while:

- **streaming every improving solution** to a user callback as the search finds them, and
- **allowing the search to be interrupted early** through an `AtomicBool`, returning the best solution found so far.

This covers two common needs that aren't reachable today through `solve`/`solve_with_parameters`: showing progress / acting on intermediate solutions, and cancelling a long solve from another thread (e.g. a UI "stop" button).

## API

```rust
pub fn solve_with_callback<F>(
    &self,
    params: &proto::SatParameters,
    stop: Option<&std::sync::atomic::AtomicBool>,
    on_solution: F,
) -> proto::CpSolverResponse
where
    F: FnMut(&proto::CpSolverResponse) + Send,
```

```rust
let mut model = CpModelBuilder::default();
let x = model.new_int_var([(0, 10)]);
model.maximize(x);

let stop = AtomicBool::new(false);
let response = model.solve_with_callback(&SatParameters::default(), Some(&stop), |resp| {
    // called for each improving solution
    println!("found objective {}", resp.objective_value);
});
```

## How it works

The C++ wrapper builds a `sat::Model` and uses the canonical OR-Tools hooks:

- `sat::NewFeasibleSolutionObserver(...)` to report each improving solution.
- `TimeLimit::RegisterExternalBooleanAsLimit(flag)` for cooperative external interruption, registered before the solver builds its shared time limit so every worker observes it.
- `sat::SolveCpModel(model_proto, &model)` to solve with the configured model.

The Rust `stop` flag is passed straight through and aliased as a `std::atomic<bool>`; two `static_assert`s guard that `std::atomic<bool>` is one byte and always lock-free before the alias is formed.

## Safety

- `F: FnMut + Send` (not `Sync`): OR-Tools serialises observer callbacks, so exclusive access is sufficient and the closure never runs concurrently with itself.
- The user closure is wrapped in `catch_unwind` so a panic can never unwind across the C++ frames (UB). On panic the search is asked to stop and the panic is re-raised on the calling thread once `Solve` returns.
- The returned buffer is guarded against the zero-size/`null` `malloc` case and freed with `libc::free`.
- The `&AtomicBool` borrow guarantees the flag outlives the solve.

## Build change (required)

`build.rs` now compiles the wrapper with `-DNDEBUG`. The new code instantiates `sat::Model::GetOrCreate<TimeLimit>`, which pulls Abseil's `flat_hash_map` out-of-line code into the wrapper object. OR-Tools' published binaries are built with `NDEBUG`; compiling the wrapper without it instantiates the *debug* variant of those containers, which references debug-only Abseil symbols absent from the release libs (an ODR violation). Matching the library's configuration fixes that. Because `assert(...)` then compiles away, the existing `res` variables are annotated `[[maybe_unused]]`. The OR-Tools include path is also switched to `-isystem` so the headers' own diagnostics stay out of the build log (consistent with the crate already assuming a Clang/GCC `-std=c++17` toolchain).

## Tests

`tests/callback.rs` covers: improving solutions are reported and the solve returns `Optimal`; a pre-set stop flag makes the solver return promptly instead of running to the time cap; and a panic inside the callback propagates to the caller.

## Notes

- No new crate dependencies; `Cargo.toml`/`Cargo.lock` are unchanged.
- No version bump — left to the maintainers.
